### PR TITLE
Fix type checking with unknown instead of Record

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -30,10 +30,10 @@ export type StyledComponentProps<TConfig extends any[]> = (TConfig[0] extends {
         keyof TConfig[0]['variants'][K]
       >;
     }
-  : Record<string, unknown>) &
+  : unknown) &
   (TConfig extends [first: any, ...rest: infer V]
     ? StyledComponentProps<V>
-    : Record<string, unknown>);
+    : unknown);
 
 export type StrictValue<T> = T extends number
   ? T


### PR DESCRIPTION
Currently, the variadic mapping of `...configs` to `props` coalesces to `Record<string, unknown>` with the intersection operator on the final config. This means any prop (`string` key) is allowed rather than only `TComponent` props. In both of the conditionals we only care about the true type while the false type should be ignored/discarded. Switching to `unknown` solves the issue.

Before:
```js
const Div = styled('div');
<Div answer="42" />
```
> Compiles

After:
```js
const Div = styled('div');
<Div answer="42" />
```
> Error: Property 'answer' does not exist on type...